### PR TITLE
Fix crash for .DS_Store files

### DIFF
--- a/Sources/FileRenamer/main.swift
+++ b/Sources/FileRenamer/main.swift
@@ -21,6 +21,7 @@ struct FileRenamer: ParsableCommand {
         let files = try fileManager.contentsOfDirectory(atPath: filesURL.path)
 
         for file in files {
+            guard file.starts(with: "wwdc2020") else { continue }
             var session = file
             session.removeFirst(9)
             session.removeLast(7)


### PR DESCRIPTION
Hello, thanks for this as I was planning to write one myself :) 

I had a crash when it was processing the `.DS_Store` file, I added a guard to check whether the file we're processing starts with `wwdc2020` prefix.